### PR TITLE
fix: add proper path

### DIFF
--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -15,7 +15,7 @@ class Libzenohc < Formula
   end
 
   def install
-    lib.install "libzenohc.dylib"
+    lib.install "lib/libzenohc.dylib"
     include.install "include/zenoh.h"
     include.install "include/zenoh_commons.h"
     include.install "include/zenoh_concrete.h"


### PR DESCRIPTION
Installing as described [here](https://zenoh.io/docs/getting-started/installation/) leads to:

```
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - libzenohc.dylib
```

- Fixed by adding the proper path
- Tested on Apple Silicon.
