### PR TITLE
fix: Change path from `lib/libzenohc.dylib` to `libzenohc.dylib`

### DIFF
--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -18,7 +18,7 @@ class Libzenohc < Formula
   end
 
   def install
-    lib.install "lib/libzenohc.dylib"
+    lib.install "libzenohc.dylib"
     include.install "include/zenoh.h"
     include.install "include/zenoh_commons.h"
     include.install "include/zenoh_concrete.h"


### PR DESCRIPTION
[See this workflow run.](https://github.com/eclipse-zenoh/zenoh-c/actions/runs/8666230403/job/23767166063)