### PR TITLE
fix: Remove zenoh dependency on libzenohc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ The zenoh public homebrew tap for OS X homebrew formulae
   <dd>Eclipse Zenoh. A meta-formula that will install the following formulae:
      <ul>
          <li><i>zenohd</i></li>
-         <li><i>zenoh-http</i></li>
-         <li><i>zenoh-storages</i></li>
-         <li><i>libzenohc</i></li>
+         <li><i>zenoh-plugin-rest</i></li>
+         <li><i>zenoh-plugin-storage-manager</i></li>
      </ul>
   </dd>
   <dt>zenohd</dt>

--- a/zenoh.rb
+++ b/zenoh.rb
@@ -7,7 +7,6 @@ class Zenoh < Formula
   homepage "https://zenoh.io"
 
   depends_on "zenohd"
-  depends_on "libzenohc" => :recommended
   depends_on "zenoh-plugin-rest" => :recommended
   depends_on "zenoh-plugin-storage-manager" => :recommended
 


### PR DESCRIPTION
The dependency on libzenohc makes testing the zenoh formula quite complicated as it relies on a formulae built outside the eclipse-zenoh/zenoh repository.

At the same time, it is odd how zenoh includes libzenohc although it is unused by the router. There is a better argument for including some of the plugins and backends.