### PR TITLE
fix: change location of libzenohc.dylib

### DIFF
--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -19,9 +19,18 @@ class Libzenohc < Formula
 
   def install
     lib.install "lib/libzenohc.dylib"
+    lib.install "lib/libzenohc.a"
+    lib.install "lib/pkgconfig/zenohc.pc"
+    lib.install "lib/cmake/zenohc/zenohcConfig.cmake"
+    lib.install "lib/cmake/zenohc/zenohcConfigVersion.cmake"
     include.install "include/zenoh.h"
     include.install "include/zenoh_commons.h"
     include.install "include/zenoh_concrete.h"
     include.install "include/zenoh_macros.h"
+    include.install "include/zenoh_configure.h"
+    include.install "include/zenoh_constants.h"
+    include.install "include/zenoh_memory.h"
+    include.install "include/zenoh_opaque.h"
+
   end
 end

--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -18,7 +18,7 @@ class Libzenohc < Formula
   end
 
   def install
-    lib.install "libzenohc.dylib"
+    lib.install "lib/libzenohc.dylib"
     include.install "include/zenoh.h"
     include.install "include/zenoh_commons.h"
     include.install "include/zenoh_concrete.h"


### PR DESCRIPTION
new packages built by cmake/cpack add the dylib under lib/

See https://github.com/eclipse-zenoh/zenoh-c/actions/runs/11596394063/job/32288282329#step:2:128