### PR TITLE
fix: correct formula class name for libzenohcpp

### DIFF
--- a/libzenohcpp.rb
+++ b/libzenohcpp.rb
@@ -1,6 +1,6 @@
 require "json"
 
-class Libzenohc < Formula
+class Libzenohcpp < Formula
   release = JSON.parse(File.read("#{__dir__}/release.json"))[File.basename(__FILE__, ".rb")]
 
   desc "Zenoh-cpp API (geo-distributed pub/sub/query/storage of data)"


### PR DESCRIPTION
See error here: https://github.com/eclipse-zenoh/zenoh-cpp/actions/runs/12157143679/job/33902310863#step:2:120