### PR TITLE
Install zenohc and zenohcxx cmake config files in lib/cmake directory

### DIFF
--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -31,5 +31,9 @@ class Libzenohc < Formula
     include.install "include/zenoh_constants.h"
     include.install "include/zenoh_memory.h"
     include.install "include/zenoh_opaque.h"
+
+    system "mkdir", "-p", "#{lib}/cmake/zenohc"
+    ln_sf "#{lib}/zenohcConfig.cmake", "#{lib}/cmake/zenohc/zenohcConfig.cmake"
+    ln_sf "#{lib}/zenohcConfigVersion.cmake", "#{lib}/cmake/zenohc/zenohcConfigVersion.cmake"
   end
 end

--- a/libzenohcpp.rb
+++ b/libzenohcpp.rb
@@ -22,5 +22,9 @@ class Libzenohcpp < Formula
     lib.install "lib/cmake/zenohcxx/zenohcxxConfig.cmake"
     lib.install "lib/cmake/zenohcxx/zenohcxxConfigVersion.cmake"
     include.install Dir["include/*"]
+
+    system "mkdir", "-p", "#{lib}/cmake/zenohcxx"
+    ln_sf "#{lib}/zenohcxxConfig.cmake", "#{lib}/cmake/zenohcxx/zenohcxxConfig.cmake"
+    ln_sf "#{lib}/zenohcxxConfigVersion.cmake", "#{lib}/cmake/zenohcxx/zenohcxxConfigVersion.cmake"
   end
 end


### PR DESCRIPTION
The `libzenohc` and `libzenohcpp` formulae currently install the cmake config files to `<prefix>/lib`. However `find_package` is not able to locate these files since they are not in the standard search paths. 

This PR adds symlinks to install the cmake config files in the `<prefix>/lib/cmake/<package_name>/` directory. 
  * Note: symlinks are used to preserve existing behavior and avoid breaking anything that depends on the current location of the cmake files.

Tested with homebrew version 4.4.31 on M1 Sonoma 

As an example, before the changes, the files installed in the zenohc `lib` directory are:

```sh
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/libzenohc.dylib
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/zenohc.pc
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/zenohcConfig.cmake
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/zenohcConfigVersion.cmake
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/libzenohc.a
```

After the changes:

```sh
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/libzenohc.dylib
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/zenohc.pc
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/cmake/zenohc
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/cmake/zenohc/zenohcConfig.cmake
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/cmake/zenohc/zenohcConfigVersion.cmake
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/zenohcConfig.cmake
/opt/homebrew/Cellar/libzenohc/1.3.3/lib/zenohcConfigVersion.cmake
```

homebrew will then symlink these files to `/opt/homebrew/lib/cmake/zenohc` so `find_package` is able to locate the package.
