### PR TITLE
fix: use Ruby mkdir instead of system mkdir

### DIFF
--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -1,4 +1,5 @@
 require "json"
+require "fileutils"
 
 class Libzenohc < Formula
   release = JSON.parse(File.read("#{__dir__}/release.json"))[File.basename(__FILE__, ".rb")]
@@ -32,7 +33,7 @@ class Libzenohc < Formula
     include.install "include/zenoh_memory.h"
     include.install "include/zenoh_opaque.h"
 
-    system "mkdir", "-p", "#{lib}/cmake/zenohc"
+    FileUtils::mkdir_p "#{lib}/cmake/zenohc"
     ln_sf "#{lib}/zenohcConfig.cmake", "#{lib}/cmake/zenohc/zenohcConfig.cmake"
     ln_sf "#{lib}/zenohcConfigVersion.cmake", "#{lib}/cmake/zenohc/zenohcConfigVersion.cmake"
   end

--- a/libzenohcpp.rb
+++ b/libzenohcpp.rb
@@ -1,4 +1,5 @@
 require "json"
+require "fileutils"
 
 class Libzenohcpp < Formula
   release = JSON.parse(File.read("#{__dir__}/release.json"))[File.basename(__FILE__, ".rb")]
@@ -23,7 +24,7 @@ class Libzenohcpp < Formula
     lib.install "lib/cmake/zenohcxx/zenohcxxConfigVersion.cmake"
     include.install Dir["include/*"]
 
-    system "mkdir", "-p", "#{lib}/cmake/zenohcxx"
+    FileUtils::mkdir_p "#{lib}/cmake/zenohcxx"
     ln_sf "#{lib}/zenohcxxConfig.cmake", "#{lib}/cmake/zenohcxx/zenohcxxConfig.cmake"
     ln_sf "#{lib}/zenohcxxConfigVersion.cmake", "#{lib}/cmake/zenohcxx/zenohcxxConfigVersion.cmake"
   end


### PR DESCRIPTION
Fix brew audit error as suggested by the tooling

Fix: https://github.com/eclipse-zenoh/zenoh-c/actions/runs/15125791786/job/42517948854 and https://github.com/eclipse-zenoh/zenoh-cpp/actions/runs/15126066491/job/42518255226