### PR TITLE
chore: fix more brew audit errors

### DIFF
--- a/libzenohc.rb
+++ b/libzenohc.rb
@@ -33,7 +33,7 @@ class Libzenohc < Formula
     include.install "include/zenoh_memory.h"
     include.install "include/zenoh_opaque.h"
 
-    FileUtils::mkdir_p "#{lib}/cmake/zenohc"
+    mkdir_p "#{lib}/cmake/zenohc"
     ln_sf "#{lib}/zenohcConfig.cmake", "#{lib}/cmake/zenohc/zenohcConfig.cmake"
     ln_sf "#{lib}/zenohcConfigVersion.cmake", "#{lib}/cmake/zenohc/zenohcConfigVersion.cmake"
   end

--- a/libzenohcpp.rb
+++ b/libzenohcpp.rb
@@ -24,7 +24,7 @@ class Libzenohcpp < Formula
     lib.install "lib/cmake/zenohcxx/zenohcxxConfigVersion.cmake"
     include.install Dir["include/*"]
 
-    FileUtils::mkdir_p "#{lib}/cmake/zenohcxx"
+    mkdir_p "#{lib}/cmake/zenohcxx"
     ln_sf "#{lib}/zenohcxxConfig.cmake", "#{lib}/cmake/zenohcxx/zenohcxxConfig.cmake"
     ln_sf "#{lib}/zenohcxxConfigVersion.cmake", "#{lib}/cmake/zenohcxx/zenohcxxConfigVersion.cmake"
   end


### PR DESCRIPTION
  * line 27, col 5: Don't need 'FileUtils.' before mkdir_p
  * line 27, col 14: Do not use `::` for method calls.

Fix: https://github.com/eclipse-zenoh/zenoh-cpp/actions/runs/15126066491/job/42551091927#step:2:59